### PR TITLE
Addded more support for initialState in createStore without a history

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -250,11 +250,19 @@ export default function undoable (reducer, rawConfig = {}) {
           }
         }
 
-        const updatedHistory = (state.present === res)
-          ? state
-          : insert(state, res, config.limit)
+        let updatedHistory
+        if (typeof state.present === 'undefined') {
+          updatedHistory = createHistory(state)
+          debug('create history on init')
+        } else if (state.present === res) {
+          updatedHistory = state
+          debug('not inserted, state is unchanged')
+        } else {
+          updatedHistory = insert(state, res, config.limit)
+          debug('inserted new state into history')
+        }
 
-        debug('after insert', {history: updatedHistory, free: config.limit - length(updatedHistory)})
+        debug('history: ', updatedHistory, ' free: ', config.limit - length(updatedHistory))
         debugEnd()
         return updatedHistory
     }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -285,6 +285,15 @@ function runTestWithConfig (testConfig, label) {
         const store = Redux.createStore(mockUndoableReducer, rehydratingState)
         expect(store.getState()).to.deep.equal(rehydratingState)
       })
+      it('should accept the initialState from `createStore` without a history', () => {
+        const reHydratingState = {'a': 'b', 'c': [1, 2, 3], 'e': {'foo': 'bbb'}}
+        const store = Redux.createStore(mockUndoableReducer, reHydratingState)
+        expect(store.getState()).to.deep.equal({
+          past: [],
+          present: {'a': 'b', 'c': [1, 2, 3], 'e': {'foo': 'bbb'}},
+          future: []
+        })
+      })
     })
   })
 }


### PR DESCRIPTION
On [Gitter](https://gitter.im/omnidan/redux-undo) @pl12133 wrote: 

> the user would have to pass in a proper history object to Redux.createStore, like 
> `{ past: [], present: 0, future: [] }`
> i think its fine to do it that way

I think it would be preferable to not change what users have to provide to `Redux.createStore` having to provide a history object makes it just a little harde (and is extra documentation in the redux-undo readme. 

Having to provide a history object indeed helps users get a better understanding of what is going on though, but this enables both and saves boilerplate :)
